### PR TITLE
spring-boot-watch-pipeline-activity to 1.0.0

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -25,6 +25,9 @@ dependencies:
 - name: react-quickstart
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: spring-boot-watch-pipeline-activity
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.0
 - name: starter1110
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.1


### PR DESCRIPTION
Promote spring-boot-watch-pipeline-activity to version 1.0.0